### PR TITLE
删除重复的VK_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR

### DIFF
--- a/modules/graphics/src/vulkan/vulkan_utils.c
+++ b/modules/graphics/src/vulkan/vulkan_utils.c
@@ -702,9 +702,6 @@ void VkUitl_QueryDynamicPipelineStates(CGPUAdapter_Vulkan* VkAdapter, uint32_t* 
         VK_DYNAMIC_STATE_BLEND_CONSTANTS,
         VK_DYNAMIC_STATE_DEPTH_BOUNDS,
         VK_DYNAMIC_STATE_STENCIL_REFERENCE
-
-        // extension:
-        // VK_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR 
     };
 
     uint32_t base_states_count = sizeof(base_states) / sizeof(VkDynamicState);


### PR DESCRIPTION
VK_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR似乎重复添加了。验证层也给提示说VkDynamicState有两条一样的。